### PR TITLE
Invert relationship between velocity and stroke width

### DIFF
--- a/SignatureDemo/NICSignatureView.m
+++ b/SignatureDemo/NICSignatureView.m
@@ -282,7 +282,7 @@ static NICSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
     float normalizedVelocity = (clampedVelocityMagnitude - VELOCITY_CLAMP_MIN) / (VELOCITY_CLAMP_MAX - VELOCITY_CLAMP_MIN);
     
     float lowPassFilterAlpha = STROKE_WIDTH_SMOOTHING;
-    float newThickness = (STROKE_WIDTH_MAX - STROKE_WIDTH_MIN) * normalizedVelocity + STROKE_WIDTH_MIN;
+    float newThickness = (STROKE_WIDTH_MAX - STROKE_WIDTH_MIN) * (1 - normalizedVelocity) + STROKE_WIDTH_MIN;
     penThickness = penThickness * lowPassFilterAlpha + newThickness * (1 - lowPassFilterAlpha);
     
     if ([p state] == UIGestureRecognizerStateBegan) {


### PR DESCRIPTION
According to the original article (and real-world experience) the more velocity, the thinner the stroke should be (because ink doesn’t have as much time to deposit on the paper).

I think that thus modified, the curves appear more natural.
