### PR TITLE
Replaces Podspec absolute path for a relative path

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,1 +1,1 @@
-pod 'PPSSignatureView', :path => '~/Documents/Code/workspace/work/PPSSignatureView/PPSSignatureView.podspec'
+pod 'PPSSignatureView', :path => '../PPSSignatureView.podspec'


### PR DESCRIPTION
Example app had a broken Podfile. 
