### PR TITLE
Set transparent layer

### DIFF
--- a/Source/PPSSignatureView.m
+++ b/Source/PPSSignatureView.m
@@ -122,7 +122,8 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
         
         self.context = context;
         self.drawableDepthFormat = GLKViewDrawableDepthFormat24;
-		self.enableSetNeedsDisplay = YES;
+	self.enableSetNeedsDisplay = YES;
+	self.layer.opaque = NO;
         
         // Turn on antialiasing
         self.drawableMultisample = GLKViewDrawableMultisample4X;
@@ -172,7 +173,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
 - (void)drawRect:(CGRect)rect
 {
-    glClearColor(1, 1, 1, 1.0f);
+    glClearColor(0.0, 0.0, 0.0, 0.0f);
     glClear(GL_COLOR_BUFFER_BIT);
 
     [effect prepareToDraw];


### PR DESCRIPTION
This patch sets the layer transparent, in order to fetch the signatureImage without a white background. 

As a side note, the background of the view must be also set to transparent in the storyboard.
