### PR TITLE
Fixes Xcode 6 and iOS 8 build issues

### DIFF
--- a/Source/PPSSignatureView.h
+++ b/Source/PPSSignatureView.h
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>
 #import <GLKit/GLKit.h>
+#import <OpenGLES/ES2/glext.h>
 
 @interface PPSSignatureView : GLKView
 


### PR DESCRIPTION
Not sure if this is an issue or a bug, but adding this additional import statement from the OpenGLES framework fixes all compiler warnings, and successfully builds and runs on iOS 8 and Xcode 6 beta 3.
