### PR TITLE
Added new properties

### DIFF
--- a/Source/PPSSignatureView.h
+++ b/Source/PPSSignatureView.h
@@ -10,6 +10,7 @@
 @property (strong, nonatomic) UIImage *signatureImage;
 @property(assign, nonatomic) BOOL longPressToEraseEnabled;
 @property(nonatomic,readonly) NSUInteger vertexCount;
+@property(assign,nonatomic) float strokeMaxWidth;
 @property(weak, nonatomic)id<PPSSignatureViewDelegate> signatureViewDelegate;
 
 - (void)erase;

--- a/Source/PPSSignatureView.h
+++ b/Source/PPSSignatureView.h
@@ -1,12 +1,22 @@
 #import <UIKit/UIKit.h>
 #import <GLKit/GLKit.h>
 
+@protocol PPSSignatureViewDelegate;
+
 @interface PPSSignatureView : GLKView
 
 @property (assign, nonatomic) UIColor *strokeColor;
 @property (assign, nonatomic) BOOL hasSignature;
 @property (strong, nonatomic) UIImage *signatureImage;
+@property(assign, nonatomic) BOOL longPressToEraseEnabled;
+@property(nonatomic,readonly) NSUInteger vertexCount;
+@property(weak, nonatomic)id<PPSSignatureViewDelegate> signatureViewDelegate;
 
 - (void)erase;
 
+@end
+
+
+@protocol PPSSignatureViewDelegate <NSObject>
+-(void)signatureDidChange:(PPSSignatureView*)signatureView;
 @end

--- a/Source/PPSSignatureView.m
+++ b/Source/PPSSignatureView.m
@@ -226,6 +226,13 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
     return screenshot;
 }
 
+#pragma mark - Properties
+
+-(NSUInteger)vertexCount
+{
+    return length;
+}
+
 
 #pragma mark - Gesture Recognizers
 
@@ -273,7 +280,8 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
 
 - (void)longPress:(UILongPressGestureRecognizer *)lp {
-    [self erase];
+    if(self.longPressToEraseEnabled)
+        [self erase];
 }
 
 - (void)pan:(UIPanGestureRecognizer *)p {
@@ -358,6 +366,9 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
     }
     
 	[self setNeedsDisplay];
+    
+    if(self.signatureViewDelegate)
+        [self.signatureViewDelegate signatureDidChange:self];
 }
 
 
@@ -370,7 +381,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 #pragma mark - Private
 
 - (void)updateStrokeColor {
-    CGFloat red, green, blue, alpha, white;
+    CGFloat red = 0.0, green = 0.0, blue = 0.0, alpha = 0.0, white = 0.0;
     if (effect && self.strokeColor && [self.strokeColor getRed:&red green:&green blue:&blue alpha:&alpha]) {
         effect.constantColor = GLKVector4Make(red, green, blue, alpha);
     } else if (effect && self.strokeColor && [self.strokeColor getWhite:&white alpha:&alpha]) {

--- a/Source/PPSSignatureView.m
+++ b/Source/PPSSignatureView.m
@@ -2,7 +2,7 @@
 #import <OpenGLES/ES2/glext.h>
 
 #define             STROKE_WIDTH_MIN 0.004 // Stroke width determined by touch velocity
-#define             STROKE_WIDTH_MAX 0.030
+#define     DEFAULT_STROKE_WIDTH_MAX 0.010
 #define       STROKE_WIDTH_SMOOTHING 0.5   // Low pass filter alpha
 
 #define           VELOCITY_CLAMP_MIN 20
@@ -128,6 +128,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
         self.context = context;
         self.drawableDepthFormat = GLKViewDrawableDepthFormat24;
 		self.enableSetNeedsDisplay = YES;
+		self.strokeMaxWidth = DEFAULT_STROKE_WIDTH_MAX;
         
         // Turn on antialiasing
         self.drawableMultisample = GLKViewDrawableMultisample4X;
@@ -302,7 +303,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
     float normalizedVelocity = (clampedVelocityMagnitude - VELOCITY_CLAMP_MIN) / (VELOCITY_CLAMP_MAX - VELOCITY_CLAMP_MIN);
     
     float lowPassFilterAlpha = STROKE_WIDTH_SMOOTHING;
-    float newThickness = (STROKE_WIDTH_MAX - STROKE_WIDTH_MIN) * (1 - normalizedVelocity) + STROKE_WIDTH_MIN;
+    float newThickness = (self.strokeMaxWidth - STROKE_WIDTH_MIN) * (1 - normalizedVelocity) + STROKE_WIDTH_MIN;
     penThickness = penThickness * lowPassFilterAlpha + newThickness * (1 - lowPassFilterAlpha);
     
     if ([p state] == UIGestureRecognizerStateBegan) {


### PR DESCRIPTION
Added the following three properties:
@property(assign, nonatomic) BOOL longPressToEraseEnabled;
@property(nonatomic,readonly) NSUInteger vertexCount;
@property(weak, nonatomic)id<PPSSignatureViewDelegate> signatureViewDelegate;

This allows to get notified once the signature has changed. Also the vertex count can be read so you can e.g. decide whether a signature is valid / contains enough vertices. Also the long press to erase function can be disabled.
