### PR TITLE
The snapshot of the signatureView is always transparent.

### DIFF
--- a/Source/PPSSignatureView.m
+++ b/Source/PPSSignatureView.m
@@ -387,10 +387,12 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
         clearColor[0] = red;
         clearColor[1] = green;
         clearColor[2] = blue;
+        clearColor[3] = alpha;
     } else if ([backgroundColor getWhite:&white alpha:&alpha]) {
         clearColor[0] = white;
         clearColor[1] = white;
         clearColor[2] = white;
+        clearColor[3] = alpha;
     }
 }
 


### PR DESCRIPTION
Setting the background of the PPSSignatureView works but it when taking a snapshot it would not result in the same image with the correct background. It will always be transparent.

This is because the `clearColor[3]` property is only set at the beginning.
To fix this I added the alpha to the `-setBackgroundColor:` method the value `alpha` was there already.

There was no way to set the background color of the snapshot. So you could end up with a view like this:
![signature_view](https://cloud.githubusercontent.com/assets/1220113/5314764/197d6f76-7c76-11e4-80cc-7a146966ffcc.png)
And a snapshot like this:
![signature_snapshot](https://cloud.githubusercontent.com/assets/1220113/5314766/1d1db7ee-7c76-11e4-8592-054df009560c.png)

All and all not a big change but it makes a big difference for me.
I'm very happy with this pod, thanks.
