### PR TITLE
Avoid crashing when OpenGL returns NULL from glMapBufferOES()

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+# EditorConfig: http://editorconfig.org
+
+[*.{m,h}]
+indent_style = space
+indent_size = 4

--- a/Source/PPSSignatureView.m
+++ b/Source/PPSSignatureView.m
@@ -57,7 +57,7 @@ static inline void addVertex(GLvoid *mappedBuffer, uint *length, PPSSignaturePoi
     (*length)++;
 }
 
-static inline void unmapVertexBuffer(GLuint *mappedBuffer) {
+static inline void unmapVertexBuffer(GLvoid *mappedBuffer) {
     if (mappedBuffer != NULL) {
         GLboolean result = glUnmapBufferOES(GL_ARRAY_BUFFER);
 
@@ -260,7 +260,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 
     if (t.state == UIGestureRecognizerStateRecognized) {
         NSError *error;
-        GLuint *mappedBuffer = mapVertexBuffer(dotsBuffer, &error);
+        GLvoid *mappedBuffer = mapVertexBuffer(dotsBuffer, &error);
 
         if (mappedBuffer == NULL) {
             // TODO(rgrimm): Handle the error condition
@@ -309,7 +309,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
 - (void)pan:(UIPanGestureRecognizer *)p {
 
     NSError *error;
-    GLuint *mappedBuffer = mapVertexBuffer(vertexBuffer, &error);
+    GLvoid *mappedBuffer = mapVertexBuffer(vertexBuffer, &error);
 
     if (mappedBuffer == NULL) {
         // TODO(rgrimm): Handle the error condition
@@ -484,7 +484,7 @@ static PPSSignaturePoint ViewPointToGL(CGPoint viewPoint, CGRect bounds, GLKVect
     previousPoint = CGPointMake(-100, -100);
 }
 
-- (void)addTriangleStripPointsInMappedBuffer:(GLuint *)mappedBuffer previous:(PPSSignaturePoint)previous next:(PPSSignaturePoint)next {
+- (void)addTriangleStripPointsInMappedBuffer:(GLvoid *)mappedBuffer previous:(PPSSignaturePoint)previous next:(PPSSignaturePoint)next {
     float toTravel = penThickness / 2.0;
 
     for (int i = 0; i < 2; i++) {

--- a/Source/PPSSignatureView.m
+++ b/Source/PPSSignatureView.m
@@ -41,7 +41,7 @@ static inline GLvoid *mapVertexBuffer(GLuint bufferToMap, NSError **error) {
         NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
         userInfo[@"GL_ERROR"] = @(glError);
 
-        *error = [NSError errorWithDomain:@"PPSSignatureVire" code:ERROR_OPENGL userInfo:userInfo];
+        *error = [NSError errorWithDomain:@"PPSSignatureView" code:ERROR_OPENGL userInfo:userInfo];
     }
 
     return data;

--- a/Source/PPSSignatureView.m
+++ b/Source/PPSSignatureView.m
@@ -41,7 +41,7 @@ static inline GLvoid *mapVertexBuffer(GLuint bufferToMap, NSError **error) {
         NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
         userInfo[@"GL_ERROR"] = @(glError);
 
-        *error = [[NSError alloc] initWithDomain:@"PPSSignatureView" code:ERROR_OPENGL userInfo:userInfo];
+        *error = [NSError errorWithDomain:@"PPSSignatureVire" code:ERROR_OPENGL userInfo:userInfo];
     }
 
     return data;


### PR DESCRIPTION
This should resolve issue #19.

Basically, the code is assuming that glMapBufferOES() will always return a valid pointer. The documentation for glMapBufferOES() states instead that null will be returned to signal an error. By ignoring the null case, the underlying OpenGL error results in a complete app crash when memcpy() tries to write data.

Following the OpenGL convention of ignoring commands if an error occurs, this code will ignore any errors that come out of OpenGL. I've dropped a few TODO comments where the code could be further improved. At least it shouldn't crash any longer.
